### PR TITLE
ファイル保存時にエラーが発生することが時々あるので解消

### DIFF
--- a/lua/ascii-fireworks/init.lua
+++ b/lua/ascii-fireworks/init.lua
@@ -129,6 +129,15 @@ local function remove_timer(timer)
 	end
 end
 
+-- タイマーを安全にクローズするヘルパー関数
+local function safe_close_timer(timer)
+	if timer and not timer:is_closing() then
+		pcall(timer.stop, timer)
+		pcall(timer.close, timer)
+		remove_timer(timer)
+	end
+end
+
 local function animate_once(bufnr, cfg, meta)
 	-- meta: { intensity=1..3, bursts={...}, max_frames, frame_interval_ms }
 	local max_frames = meta.max_frames
@@ -142,9 +151,7 @@ local function animate_once(bufnr, cfg, meta)
 		meta.frame_interval_ms,
 		vim.schedule_wrap(function()
 			if not vim.api.nvim_buf_is_loaded(bufnr) then
-				timer:stop()
-				timer:close()
-				remove_timer(timer)
+				safe_close_timer(timer)
 				return
 			end
 			clear_extmarks(bufnr)
@@ -166,9 +173,7 @@ local function animate_once(bufnr, cfg, meta)
 			frame = frame + 1
 			if frame > max_frames then
 				clear_extmarks(bufnr)
-				timer:stop()
-				timer:close()
-				remove_timer(timer)
+				safe_close_timer(timer)
 			end
 		end)
 	)


### PR DESCRIPTION
## エラーの背景と修正理由

  - 発生していた問題
```
  handle 0x60000357fac0 is already closing
```
  このエラーは、同じタイマーハンドルを2回クローズしようとした際に発生するものです。

  - 問題が起きる仕組み

  元のコードでは、animate_once
  関数内で以下の2つの異なる条件でタイマーをクローズしていました：
```
  1. バッファがアンロードされた場合（153-155行）
  if not vim.api.nvim_buf_is_loaded(bufnr) then
      safe_close_timer(timer)  -- 旧: timer:stop() → timer:close()
      return
  end
  2. アニメーション完了時（174-176行）
  if frame > max_frames then
      clear_extmarks(bufnr)
      safe_close_timer(timer)  -- 旧: timer:stop() → timer:close()
  end
```
  - 競合状態の発生パターン

  以下のようなタイミングの問題で重複クローズが発生していました：

  1. アニメーションの最終フレーム処理中に、ユーザーがバッファを閉じる
  2. 条件1でタイマーをクローズ
  3.
  同じフレーム処理で条件2も満たされ、既にクローズされたタイマーを再度クローズしようとする
  4. → already closing エラー

  修正のアプローチ

  safe_close_timer() 関数を導入して、タイマーの状態を事前チェック：

  local function safe_close_timer(timer)
      if timer and not timer:is_closing() then  -- 既にクローズ中でないかチェック
          pcall(timer.stop, timer)              -- エラーハンドリング付きで停止
          pcall(timer.close, timer)             -- エラーハンドリング付きでクローズ
          remove_timer(timer)                   -- 配列から削除
      end
  end

  修正の効果

  - 重複クローズ防止: timer:is_closing() で状態確認
  - エラー耐性: pcall でAPI呼び出しエラーをキャッチ
  - リソース管理: 確実にタイマー配列からも削除
  - 保守性向上: タイマークローズ処理が一箇所に集約

  これにより、どのような順序でクローズ処理が呼ばれても安全に動作します。

## err
```
msg_show.lua_error Error executing vim.schedule lua callback: ...e/nvim/lazy/ascii-fireworks/lua/ascii-fireworks/init.lua:170: handle 0x60000357fac0 is already closing
stack traceback:
	[C]: in function 'close'
	...e/nvim/lazy/ascii-fireworks/lua/ascii-fireworks/init.lua:170: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```